### PR TITLE
[Docs] Fix inconsistencies and typos in API documentation

### DIFF
--- a/api.html
+++ b/api.html
@@ -188,22 +188,22 @@
                                 <td>componentName</td>
                                 <td data-i18n="use.api.query.param.componentName">컴포넌트명</td>
                                 <td>string</td>
-                                <td>N</td>
+                                <td>Y</td>
                                 <td>zlib</td>
                             </tr>
                             <tr>
                                 <td>licenseName</td>
                                 <td data-i18n="use.api.query.param.licenseName">라이선스명</td>
                                 <td>string</td>
-                                <td>N</td>
-                                <td>MIT License</td>
+                                <td>Y</td>
+                                <td>zlib</td>
                             </tr>
                             <tr>
                                 <td>security</td>
                                 <td data-i18n="use.api.query.param.security">보안취약점<br>
                                     - None, Low, Medium, High, Critical</td>
                                 <td>string</td>
-                                <td>N</td>
+                                <td>Y</td>
                                 <td>Low</td>
                             </tr>
                             <tr>
@@ -217,16 +217,14 @@
                             </tr>
                             <tr>
                                 <td>page</td>
-                                <td data-i18n="use.api.query.param.page">시작 page 숫자(필수값) <br>
-                                    - 기본값: 0</td>
+                                <td data-i18n="use.api.query.param.page">시작 page 숫자(필수값) </td>
                                 <td>int</td>
                                 <td>Y</td>
                                 <td>0</td>
                             </tr>
                             <tr>
                                 <td>size</td>
-                                <td data-i18n="use.api.query.param.size">페이지당 결과 수<br>
-                                    - 기본값: 10</td>
+                                <td data-i18n="use.api.query.param.size">페이지당 결과 수<br> </td>
                                 <td>int</td>
                                 <td>Y</td>
                                 <td>10</td>
@@ -238,7 +236,7 @@
                                 </td>
                                 <td>string</td>
                                 <td>Y</td>
-                                <td>name</td>
+                                <td>componentName</td>
                             </tr>
                             <tr>
                                 <td>direction</td>
@@ -261,7 +259,7 @@
                             <button onclick="copyToClipboard(this)">📋 <span data-i18n="button.copy">복사</span></button>
                             <button onclick="editCode(this)">✏️ <span data-i18n="button.edit">편집</span></button>
                         </div>
-                        <pre><code contenteditable="false">curl --location --request GET 'https://techmap.kr/api/v1/component?componentName=zlib&licenseName=MIT' ^ --header "Authorization: Bearer krhxnqw3jPMkdqYsbVQQMVKZ85p2RWWqa8KFlfmZA80"</code></pre>
+                        <pre><code contenteditable="false">curl --location --request GET 'https://techmap.kr/api/v1/component?componentName=zlib&licenseName=zlib&security=Low&equalFlag=Y&page=0&size=10&sort=componentName&direction=DESC' ^ --header "Authorization: Bearer krhxnqw3jPMkdqYsbVQQMVKZ85p2RWWqa8KFlfmZA80"</code></pre>
                     </div>
                 </div>
 
@@ -289,23 +287,23 @@
   "components": [
     {
       "component_name": "zlib",
-      "description": "Compression library used in many systems",
+      "description": "zlib is designed to be a free, general-purpose, legally unencumbered -- that is, not covered by any patents -- lossless data-compression library for use on virtually any computer hardware and operating system. The zlib data format is itself portable across platforms. Unlike the LZW compression method used in Unix compress(1) and in the GIF image format, the compression method currently used in zlib essentially never expands the data. (LZW can double or triple the file size in extreme cases.) zlib's memory footprint is also independent of the input data and can be reduced, if necessary, at some cost in compression.",
       "versions": [
         {
           "version": "1.2.11",
-          "homepage": "https://github.com/madler/zlib",
-          "security_vuln": "low",
+          "homepage": "https://zlib.net",
+          "security_vuln": "Critical",
           "licenses":  [
             {
-            "name": "zlib License",
+            "license_name": "zlib License",
             "license_risk": "Permissive",
             }
            ],
         },
         {
-          "version": "1.2.10",
-          "homepage": "https://github.com/madler/zlib",
-          "security_vuln": "High",
+          "version": "1.2.1",
+          "homepage": "https://zlib.net",
+          "security_vuln": "Critical",
           "licenses":  [
             {
             "license_name": "zlib License",
@@ -319,8 +317,8 @@
   "equalFlag": "Y",
   "page": 0,
   "size": 10,
-  "sort": "name",
-  "direction": "ASC"
+  "sort": "componentName",
+  "direction": "DESC"
 }
                         </code></pre>
                     </div>

--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
                     <p class="tit" data-aos="fade-up" data-aos-duration="1400" data-aos-delay="200" data-aos-once="true"
                         data-i18n="description.techmap">
                         <strong class="blue">자동차 테크맵</strong>은 자동차 분야 <br class="only_mb" />오픈소스 기술 정보를 서로 공유하여 <br />
-                        <strong>모빌리티 공급망내 모든기업들이 <br class="only_mb" />함께 활용하고 기여하며 성장하는 <br class="only_mb" />에코
+                        <strong>모빌리티 공급망 내 모든기업들이 <br class="only_mb" />함께 활용하고 기여하며 성장하는 <br class="only_mb" />에코
                             시스템</strong> 입니다
                     </p>
                     <div class="img_wrap" data-aos="fade-up" data-aos-duration="1400" data-aos-delay="300"

--- a/translations.js
+++ b/translations.js
@@ -73,7 +73,7 @@ const translations = {
                     <br class="only_mb" />오픈소스 기술 정보를 서로 공유하여 
                     <br />
                     <strong>
-                        모빌리티 공급망내 모든기업들이 
+                        모빌리티 공급망 내 모든기업들이 
                         <br class="only_mb" />함께 활용하고 기여하며 성장하는 
                         <br class="only_mb" />에코 시스템
                     </strong> 입니다

--- a/translations.js
+++ b/translations.js
@@ -233,8 +233,8 @@ const translations = {
         "use.api.query.param.licenseName": "라이선스명",
         "use.api.query.param.security": "보안취약점 <br> - None, Low, Medium, High, Critical",
         "use.api.query.param.equalFlag": "검색결과 대상을 지정할 때 사용합니다.<br> - 'Y': 정확 일치 <br> - 'N': 포함 검색(기본값)",
-        "use.api.query.param.page": "시작 page 숫자(필수값) <br> - 기본값: 0",
-        "use.api.query.param.size": "페이지당 결과 수(필수값) <br> - 기본값: 10",
+        "use.api.query.param.page": "시작 page 숫자(필수값)",
+        "use.api.query.param.size": "페이지당 결과 수(필수값)",
         "use.api.query.param.sort": "정렬 기준 항목(필수값) <br> - componentName / licenseName",
         "use.api.query.param.direction": "정렬 방향 <br> - ASC: 오름차순 (기본값) / DESC: 내림차순",
 


### PR DESCRIPTION
## 주요 수정 사항

1. **사용 예제와 Query 파라미터 불일치 수정**

   * 기존에는 Query 파라미터와 사용 예제가 서로 다른 값을 보여주어 혼동을 줄 수 있었음
   * Query 파라미터의 예시와 동일하도록 사용 예제를 수정

2. **필수값(Y)와 기본값(default) 모순 해결**

   * `page`, `size`는 필수값(Y)로 표기되어 있으나 동시에 기본값이 존재하는 모순 발견
   * 필수값인 경우 기본값을 제거하고, 기본값이 있는 경우 필수 여부를 `N`으로 변경

3. **파라미터 명칭 변경**

   * 정렬 기준에 사용되는 항목은 제한적임에도 불구하고, `name`이란 표현이 포함되어 있어 혼동 발생
   * 이를 보다 명확하게 `componentName`으로 변경

4. **응답 Body 수정**

   * `licenses` 배열 내 `name` → `license_name` 으로 수정 (정확한 명칭 반영)
   * `zlib` 검색 시 `github` 주소가 아닌 실제 공식 사이트(`https://zlib.net`)를 반환하도록 수정

---

## 기대 효과

* 문서와 실제 동작 간의 불일치를 해소하여 사용자 혼란 최소화
* API 문서의 가독성과 신뢰도 향상
